### PR TITLE
Added fastApi CLI to be installeds as a part of project setup.

### DIFF
--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -53,7 +53,7 @@ At this point, your directory structure should look like this:
 Now, let us install FastAPI within the virtual environment. We shall install FastAPI using `pip` with the following command.
 
 ```console
-(env) pip install fastapi
+(env) pip install fastapi 'fastapi[standard]'
 ```
 
 ### 4. Freeze Dependencies


### PR DESCRIPTION
Updating pip install fastapi --> pip install fastapi 'fastapi['standard'] 
As fastapi cli is used to check the version but not installed so updating the same in the doc so it avoids confusion while running fastapi --version command.